### PR TITLE
カスタムセルに部品を配置

### DIFF
--- a/FoldingMemoApp/Views/MemoDetailTableViewCell.xib
+++ b/FoldingMemoApp/Views/MemoDetailTableViewCell.xib
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="177"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="qvA-AW-OX8">
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="749" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="qvA-AW-OX8">
                         <rect key="frame" x="16" y="41" width="288" height="127"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
@@ -33,30 +33,30 @@
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y5Q-Pv-BlM">
                         <rect key="frame" x="240" y="8" width="36" height="30"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="36" id="vSN-5h-uyG"/>
+                            <constraint firstAttribute="width" constant="36" id="vSN-GK-Ayi"/>
                         </constraints>
                         <state key="normal" title="more"/>
                     </button>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RUP-it-eZu">
                         <rect key="frame" x="284" y="12" width="20" height="22"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="20" id="A0H-LM-dNR"/>
+                            <constraint firstAttribute="width" constant="20" id="JVu-1b-O2N"/>
                         </constraints>
                         <state key="normal" image="chevron.up.circle" catalog="system"/>
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="qvA-AW-OX8" secondAttribute="bottom" constant="9" id="HDN-QP-VPO"/>
-                    <constraint firstItem="qvA-AW-OX8" firstAttribute="top" secondItem="W1x-ZC-ZFv" secondAttribute="bottom" constant="8.5" id="MU6-II-BH2"/>
-                    <constraint firstItem="Y5Q-Pv-BlM" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="OYo-jp-djx"/>
-                    <constraint firstItem="W1x-ZC-ZFv" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="14" id="Qhd-oW-W1I"/>
-                    <constraint firstItem="RUP-it-eZu" firstAttribute="leading" secondItem="Y5Q-Pv-BlM" secondAttribute="trailing" constant="8" symbolic="YES" id="U5b-I6-7P2"/>
-                    <constraint firstItem="RUP-it-eZu" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="d9T-Qe-vZ0"/>
-                    <constraint firstItem="qvA-AW-OX8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="fUW-je-ArU"/>
-                    <constraint firstAttribute="trailing" secondItem="RUP-it-eZu" secondAttribute="trailing" constant="16" id="gZo-aj-w3t"/>
-                    <constraint firstItem="Y5Q-Pv-BlM" firstAttribute="leading" secondItem="W1x-ZC-ZFv" secondAttribute="trailing" constant="8" symbolic="YES" id="lVy-J0-nKN"/>
-                    <constraint firstAttribute="trailing" secondItem="qvA-AW-OX8" secondAttribute="trailing" constant="16" id="wdq-Tm-EQn"/>
-                    <constraint firstItem="W1x-ZC-ZFv" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="zlN-8E-vmf"/>
+                    <constraint firstItem="qvA-AW-OX8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="72o-A9-rGK"/>
+                    <constraint firstItem="W1x-ZC-ZFv" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="CX1-z8-mPs"/>
+                    <constraint firstItem="Y5Q-Pv-BlM" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="Ecw-Qp-HrH"/>
+                    <constraint firstItem="qvA-AW-OX8" firstAttribute="top" secondItem="Y5Q-Pv-BlM" secondAttribute="bottom" constant="3" id="Gzu-PA-6Ne"/>
+                    <constraint firstAttribute="bottom" secondItem="qvA-AW-OX8" secondAttribute="bottom" constant="9" id="NUs-nB-ZE4"/>
+                    <constraint firstItem="Y5Q-Pv-BlM" firstAttribute="leading" secondItem="W1x-ZC-ZFv" secondAttribute="trailing" constant="8" symbolic="YES" id="NWQ-oz-aHr"/>
+                    <constraint firstAttribute="trailing" secondItem="qvA-AW-OX8" secondAttribute="trailing" constant="16" id="NWU-rL-ixl"/>
+                    <constraint firstItem="RUP-it-eZu" firstAttribute="leading" secondItem="Y5Q-Pv-BlM" secondAttribute="trailing" constant="8" symbolic="YES" id="bwJ-1X-2Ig"/>
+                    <constraint firstAttribute="trailing" secondItem="RUP-it-eZu" secondAttribute="trailing" constant="16" id="gzC-Z1-XOJ"/>
+                    <constraint firstItem="RUP-it-eZu" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="q6n-rJ-nrE"/>
+                    <constraint firstItem="W1x-ZC-ZFv" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="14" id="vrS-6z-6fY"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>

--- a/FoldingMemoApp/Views/MemoDetailTableViewCell.xib
+++ b/FoldingMemoApp/Views/MemoDetailTableViewCell.xib
@@ -31,14 +31,14 @@
                         <textInputTraits key="textInputTraits"/>
                     </textField>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y5Q-Pv-BlM">
-                        <rect key="frame" x="240" y="8" width="36" height="30"/>
+                        <rect key="frame" x="240" y="8.5" width="36" height="30"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="36" id="vSN-GK-Ayi"/>
                         </constraints>
                         <state key="normal" title="more"/>
                     </button>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RUP-it-eZu">
-                        <rect key="frame" x="284" y="12" width="20" height="22"/>
+                        <rect key="frame" x="284" y="12.5" width="20" height="22"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="20" id="JVu-1b-O2N"/>
                         </constraints>
@@ -48,15 +48,15 @@
                 <constraints>
                     <constraint firstItem="qvA-AW-OX8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="72o-A9-rGK"/>
                     <constraint firstItem="W1x-ZC-ZFv" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="CX1-z8-mPs"/>
-                    <constraint firstItem="Y5Q-Pv-BlM" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="Ecw-Qp-HrH"/>
-                    <constraint firstItem="qvA-AW-OX8" firstAttribute="top" secondItem="Y5Q-Pv-BlM" secondAttribute="bottom" constant="3" id="Gzu-PA-6Ne"/>
+                    <constraint firstItem="Y5Q-Pv-BlM" firstAttribute="centerY" secondItem="W1x-ZC-ZFv" secondAttribute="centerY" id="IOd-gf-5ZG"/>
                     <constraint firstAttribute="bottom" secondItem="qvA-AW-OX8" secondAttribute="bottom" constant="9" id="NUs-nB-ZE4"/>
                     <constraint firstItem="Y5Q-Pv-BlM" firstAttribute="leading" secondItem="W1x-ZC-ZFv" secondAttribute="trailing" constant="8" symbolic="YES" id="NWQ-oz-aHr"/>
                     <constraint firstAttribute="trailing" secondItem="qvA-AW-OX8" secondAttribute="trailing" constant="16" id="NWU-rL-ixl"/>
+                    <constraint firstItem="RUP-it-eZu" firstAttribute="centerY" secondItem="W1x-ZC-ZFv" secondAttribute="centerY" id="QVm-A9-fxY"/>
                     <constraint firstItem="RUP-it-eZu" firstAttribute="leading" secondItem="Y5Q-Pv-BlM" secondAttribute="trailing" constant="8" symbolic="YES" id="bwJ-1X-2Ig"/>
                     <constraint firstAttribute="trailing" secondItem="RUP-it-eZu" secondAttribute="trailing" constant="16" id="gzC-Z1-XOJ"/>
-                    <constraint firstItem="RUP-it-eZu" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="q6n-rJ-nrE"/>
                     <constraint firstItem="W1x-ZC-ZFv" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="14" id="vrS-6z-6fY"/>
+                    <constraint firstItem="qvA-AW-OX8" firstAttribute="top" secondItem="W1x-ZC-ZFv" secondAttribute="bottom" constant="8.5" id="zrD-mv-PZy"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>

--- a/FoldingMemoApp/Views/MemoDetailTableViewCell.xib
+++ b/FoldingMemoApp/Views/MemoDetailTableViewCell.xib
@@ -1,21 +1,75 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="MemoDetailTableViewCell" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="177" id="KGk-i7-Jjw" customClass="MemoDetailTableViewCell" customModule="FoldingMemoApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="177"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="177"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="qvA-AW-OX8">
+                        <rect key="frame" x="16" y="48" width="288" height="118"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                        <color key="textColor" systemColor="labelColor"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                    </textView>
+                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="W1x-ZC-ZFv">
+                        <rect key="frame" x="16" y="12" width="216" height="34"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <textInputTraits key="textInputTraits"/>
+                    </textField>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RUP-it-eZu">
+                        <rect key="frame" x="284" y="18" width="20" height="22"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="20" id="A0H-LM-dNR"/>
+                        </constraints>
+                        <state key="normal" image="chevron.up.circle" catalog="system"/>
+                    </button>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y5Q-Pv-BlM">
+                        <rect key="frame" x="240" y="14" width="36" height="30"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="36" id="vSN-5h-uyG"/>
+                        </constraints>
+                        <state key="normal" title="more"/>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="qvA-AW-OX8" secondAttribute="bottom" constant="11" id="HDN-QP-VPO"/>
+                    <constraint firstItem="qvA-AW-OX8" firstAttribute="top" secondItem="W1x-ZC-ZFv" secondAttribute="bottom" constant="2" id="MU6-II-BH2"/>
+                    <constraint firstItem="Y5Q-Pv-BlM" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="14" id="OYo-jp-djx"/>
+                    <constraint firstItem="W1x-ZC-ZFv" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="Qhd-oW-W1I"/>
+                    <constraint firstItem="RUP-it-eZu" firstAttribute="leading" secondItem="Y5Q-Pv-BlM" secondAttribute="trailing" constant="8" symbolic="YES" id="U5b-I6-7P2"/>
+                    <constraint firstItem="RUP-it-eZu" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="18" id="d9T-Qe-vZ0"/>
+                    <constraint firstItem="qvA-AW-OX8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="fUW-je-ArU"/>
+                    <constraint firstAttribute="trailing" secondItem="RUP-it-eZu" secondAttribute="trailing" constant="16" id="gZo-aj-w3t"/>
+                    <constraint firstItem="Y5Q-Pv-BlM" firstAttribute="leading" secondItem="W1x-ZC-ZFv" secondAttribute="trailing" constant="8" symbolic="YES" id="lVy-J0-nKN"/>
+                    <constraint firstAttribute="trailing" secondItem="qvA-AW-OX8" secondAttribute="trailing" constant="16" id="wdq-Tm-EQn"/>
+                    <constraint firstItem="W1x-ZC-ZFv" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="zlN-8E-vmf"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="327.536231884058" y="214.62053571428569"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <image name="chevron.up.circle" catalog="system" width="128" height="121"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/FoldingMemoApp/Views/MemoDetailTableViewCell.xib
+++ b/FoldingMemoApp/Views/MemoDetailTableViewCell.xib
@@ -18,40 +18,40 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="qvA-AW-OX8">
-                        <rect key="frame" x="16" y="48" width="288" height="118"/>
+                        <rect key="frame" x="16" y="41" width="288" height="127"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                         <color key="textColor" systemColor="labelColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                     </textView>
-                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="W1x-ZC-ZFv">
-                        <rect key="frame" x="16" y="12" width="216" height="34"/>
+                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="タイトルの入力" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="W1x-ZC-ZFv">
+                        <rect key="frame" x="16" y="14" width="216" height="18.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RUP-it-eZu">
-                        <rect key="frame" x="284" y="18" width="20" height="22"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="20" id="A0H-LM-dNR"/>
-                        </constraints>
-                        <state key="normal" image="chevron.up.circle" catalog="system"/>
-                    </button>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y5Q-Pv-BlM">
-                        <rect key="frame" x="240" y="14" width="36" height="30"/>
+                        <rect key="frame" x="240" y="8" width="36" height="30"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="36" id="vSN-5h-uyG"/>
                         </constraints>
                         <state key="normal" title="more"/>
                     </button>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RUP-it-eZu">
+                        <rect key="frame" x="284" y="12" width="20" height="22"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="20" id="A0H-LM-dNR"/>
+                        </constraints>
+                        <state key="normal" image="chevron.up.circle" catalog="system"/>
+                    </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="qvA-AW-OX8" secondAttribute="bottom" constant="11" id="HDN-QP-VPO"/>
-                    <constraint firstItem="qvA-AW-OX8" firstAttribute="top" secondItem="W1x-ZC-ZFv" secondAttribute="bottom" constant="2" id="MU6-II-BH2"/>
-                    <constraint firstItem="Y5Q-Pv-BlM" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="14" id="OYo-jp-djx"/>
-                    <constraint firstItem="W1x-ZC-ZFv" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="Qhd-oW-W1I"/>
+                    <constraint firstAttribute="bottom" secondItem="qvA-AW-OX8" secondAttribute="bottom" constant="9" id="HDN-QP-VPO"/>
+                    <constraint firstItem="qvA-AW-OX8" firstAttribute="top" secondItem="W1x-ZC-ZFv" secondAttribute="bottom" constant="8.5" id="MU6-II-BH2"/>
+                    <constraint firstItem="Y5Q-Pv-BlM" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="OYo-jp-djx"/>
+                    <constraint firstItem="W1x-ZC-ZFv" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="14" id="Qhd-oW-W1I"/>
                     <constraint firstItem="RUP-it-eZu" firstAttribute="leading" secondItem="Y5Q-Pv-BlM" secondAttribute="trailing" constant="8" symbolic="YES" id="U5b-I6-7P2"/>
-                    <constraint firstItem="RUP-it-eZu" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="18" id="d9T-Qe-vZ0"/>
+                    <constraint firstItem="RUP-it-eZu" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="d9T-Qe-vZ0"/>
                     <constraint firstItem="qvA-AW-OX8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="fUW-je-ArU"/>
                     <constraint firstAttribute="trailing" secondItem="RUP-it-eZu" secondAttribute="trailing" constant="16" id="gZo-aj-w3t"/>
                     <constraint firstItem="Y5Q-Pv-BlM" firstAttribute="leading" secondItem="W1x-ZC-ZFv" secondAttribute="trailing" constant="8" symbolic="YES" id="lVy-J0-nKN"/>


### PR DESCRIPTION
## 今回行った作業の詳細を記入
<!--具体的にどんな作業を行ったのか記入してください -->
#5 
- 小タイトルテキストフィールド配置
  - テキストフィールドの枠は無くしました。（見た目的にこっちが良いかなと思い）
- メモ入力用テキストビュー配置
- テキストフィールド開閉ボタン配置
- メモ入力テキストビュー行数変更ボタン配置
  - moreボタンの位置は変更しました。

## レビューして欲しい内容
- AutoLayoutの設定
- ~現状のままシミュレーターで確認するとセル全体が表示されません~
  - ~これはxibファイルの方で設定できるのでしょうか？~
  - ~TableViewの方で設定できるみたいですが、セルに合わせた高さにする方法は調べ中です~
  - ~これはこのissueの範囲か分からなかったので、一旦そのままUPさせていただきました~
  - ScrollEnabledのチェックを外すことで一旦全体の表示をすることができました。

<!-- 特にレビューして欲しいところがあれば記入してください -->

## 勉強になったところ
- AutoLayoutの付け方
<!-- 今回の作業で勉強になったことを記入してください -->

## 躓いたところ
- カスタムセルのサイズに合わせたTableViewのセルの高さを可変にする方法
<!-- 今回の作業でわからなかったこと、躓いたところがあれば記入してください -->

## 参考になった資料などあれば共有してください

<!-- 今回の作業で調べて参考にした資料や記事等あればURLを貼ってみんなに共有しましょう!! -->

## スクリーンショット
カスタムセル（修正後）
<img src="https://user-images.githubusercontent.com/52493391/120888842-84e37e80-c635-11eb-968a-a160c930e882.png" width="340">
シミュレーター上での見え方
<img src="https://user-images.githubusercontent.com/52493391/120064857-54d23380-c0a9-11eb-817d-a069f3b54f80.png" width="340">
<!-- もし画像などあれば貼ってみてください-->

## その他
<!-- 上記以外でも共有したいことがあればこちらに記入してください -->